### PR TITLE
Introduced Channel to topic for NVRs

### DIFF
--- a/script/dvr-alarm-server.py
+++ b/script/dvr-alarm-server.py
@@ -81,7 +81,10 @@ class AlarmServerHandler(socketserver.BaseRequestHandler):
         json_data = json.loads(payload)
         event_type = json_data.get('Type')
         event = json_data.get('Event')
-        serialID = json_data.get('SerialID')
+        if "Channel" in json_data:
+          serialID = str(json_data.get('SerialID')) + "/" + str(json_data.get('Channel'))
+        else:
+          serialID = json_data.get('SerialID')
 
         LOG.log_info ("{} Serial: {}; Event: {}".format(event_type, serialID, event))
 


### PR DESCRIPTION
Hi tall-r,

thank you very much for this bridge for XMeye Alarmserver to MQTT. I tried to get it working in my openhab ecosystem and had struggels because the channel is only avaiable in the payload.

I've patched the file and introduced the channel appended to the NVR's serial so that each channel has its own topic.

Please merge this change for others, thanks :-)

Best regards,
Sascha